### PR TITLE
Added an implementation for elevation bumping

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/Simulation.iml
+++ b/.idea/Simulation.iml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
+    </content>
+    <orderEntry type="jdk" jdkName="Python 3.8" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="GOOGLE" />
+    <option name="myDocStringFormat" value="Google" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.8" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/Simulation.iml" filepath="$PROJECT_DIR$/.idea/Simulation.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GithubSharedProjectSettings">
+    <option name="branchProtectionPatterns">
+      <list>
+        <option value="master" />
+      </list>
+    </option>
+  </component>
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/examples/max_distance_from_speed_using_arrays.py
+++ b/examples/max_distance_from_speed_using_arrays.py
@@ -32,7 +32,7 @@ def main():
       Keep in mind, however, that the condition len(input_speed) <= simulation_length must be true
     """
 
-    simulation_model = simulation.Simulation(race_type="FSGP")
+    simulation_model = simulation.Simulation(race_type="ASC")
     distance_travelled = simulation_model.run_model(speed=input_speed, plot_results=True)
     
     optimized = simulation_model.optimize()

--- a/examples/max_distance_from_speed_using_arrays.py
+++ b/examples/max_distance_from_speed_using_arrays.py
@@ -42,6 +42,5 @@ def main():
 
     return distance_travelled
 
-
 if __name__ == "__main__":
     main()

--- a/simulation/.idea/.gitignore
+++ b/simulation/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/simulation/.idea/inspectionProfiles/profiles_settings.xml
+++ b/simulation/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/simulation/.idea/misc.xml
+++ b/simulation/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.8" project-jdk-type="Python SDK" />
+</project>

--- a/simulation/.idea/modules.xml
+++ b/simulation/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/simulation.iml" filepath="$PROJECT_DIR$/.idea/simulation.iml" />
+    </modules>
+  </component>
+</project>

--- a/simulation/.idea/simulation.iml
+++ b/simulation/.idea/simulation.iml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="GOOGLE" />
+    <option name="myDocStringFormat" value="Google" />
+  </component>
+  <component name="TestRunnerService">
+    <option name="PROJECT_TEST_RUNNER" value="pytest" />
+  </component>
+</module>

--- a/simulation/.idea/vcs.xml
+++ b/simulation/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/simulation/common/helpers.py
+++ b/simulation/common/helpers.py
@@ -33,20 +33,23 @@ def date_from_unix_timestamp(unix_timestamp):
     return datetime.utcfromtimestamp(unix_timestamp).strftime('%Y-%m-%d %H:%M:%S')
 
 
-def checkForNonConsecutiveZeros(array):
+def checkForNonConsecutiveZeros(array, verbose=False):
     zeroed_indices = np.where(array == 0)[0]
 
     if len(zeroed_indices) == 0:
-        print("No zeroes found in the array!")
+        if verbose:
+            print("No zeroes found in the array!")
         return -1
 
     zeroed_indices_diff = np.diff(zeroed_indices)
 
     if np.max(zeroed_indices_diff) == 1 and np.min(zeroed_indices_diff) == 1:
-        print("Only consecutive zeroes found!")
+        if verbose:
+            print("Only consecutive zeroes found!")
         return False
     else:
-        print("Non-consecutive zeroes found!")
+        if verbose:
+            print("Non-consecutive zeroes found!")
         return True
 
 

--- a/simulation/common/helpers.py
+++ b/simulation/common/helpers.py
@@ -5,6 +5,7 @@ import datetime
 from _datetime import datetime
 from _datetime import date
 
+from matplotlib import pyplot as plt
 from numba import jit, njit
 
 from simulation.common import constants
@@ -369,6 +370,28 @@ def find_runs(x):
 
         return run_values, run_starts, run_lengths
 
+def plot_array(array, title, x_title, y_title):
+    y1 = np.array(array)
+    x1 = np.arange(0.0, len(array), 1)
+
+    fig, ax = plt.subplots()
+    ax.plot(x1, y1)
+    ax.set(xlabel=x_title, ylabel=y_title, title=title)
+    ax.grid()
+
+    plt.show()
+
+def plot_array(array, title, x_title, y_title):
+    y1 = np.array(array)
+    x1 = np.arange(0.0, len(array), 1)
+
+    fig, ax = plt.subplots()
+    ax.plot(x1, y1)
+    ax.set(xlabel=x_title, ylabel=y_title, title=title)
+    ax.grid()
+
+    plt.show()
+
 
 if __name__ == '__main__':
     # speed_array input
@@ -380,3 +403,4 @@ if __name__ == '__main__':
     print(expanded_speed_array)
 
     pass
+

--- a/simulation/config/settings_ASC.json
+++ b/simulation/config/settings_ASC.json
@@ -13,7 +13,7 @@
     ],
 
     "tick": 1,
-    "simulation_duration": 36000,
+    "simulation_duration": 43200,
     "start_hour": 7,
 
     "initial_battery_charge": 0.65,

--- a/simulation/config/settings_FSGP.json
+++ b/simulation/config/settings_FSGP.json
@@ -14,7 +14,7 @@
 
     "tick": 1,
     "simulation_duration": 43200,
-    "start_hour": 9,
+    "start_hour": 8,
 
     "initial_battery_charge": 1.0,
     "lvs_power_loss": 0,

--- a/simulation/environment/GIS.py
+++ b/simulation/environment/GIS.py
@@ -413,69 +413,70 @@ class GIS:
 
         return self.path
 
-    def elevation_bumping_plots(self, not_charge, not_day, elevations, show_plot=True):
-
-        # Boolean array to describe charging time vs driving time (0 - charging, 1 - charging)
-        x1 = np.arange(0.0, len(not_charge), 1)
-        y1 = np.array(not_charge)
-
-        # Boolean array to describe day vs night (0 - night, 1 - day)
-
-        x2 = np.arange(0.0, len(not_day), 1)
-        y2 = np.array(not_day)
+    def elevation_bumping_plots(self, not_charge, not_day, elevations, show_plot=False):
 
         # Create a stop array to describe motion when the car is not charging and day time
-
         stop_array_y3 = np.logical_and(not_day, not_charge)
-        x3 = np.arange(0.0, len(stop_array_y3), 1)
 
-        x4 = np.arange(0.0, len(elevations), 1)
-
-        fig, (ax1, ax2, ax3, ax4, ax5) = plt.subplots(5, 1, figsize=(12, 12))
-        fig.suptitle('Elevation bumping plots')
-
-        # Plot to describe time driving
-
-        ax1.plot(x1, y1)
-        ax1.set_xlabel('time (s)')
-        ax1.set_ylabel('Driving?')
-        ax1.grid()
-
-        # Plot to describe daytime
-
-        ax2.plot(x2, y2)
-        ax2.set_xlabel('time (s)')
-        ax2.set_ylabel('Daytime?')
-        ax2.grid()
-
-        # Plot to describe time in motion
-
-        ax3.plot(x3, stop_array_y3)
-        ax3.set_xlabel('time (s)')
-        ax3.set_ylabel('In Motion?')
-        ax3.grid()
-
-        # Plot to describe elevations without adjustment for race hours
-
-        ax4.plot(x4, elevations)
-        ax4.set_xlabel('time (s)')
-        ax4.set_ylabel('Elevations (not adjusted)')
-        ax4.grid()
 
         # Perform elevation "bumping" operation
 
         modified_elevations = self.bump_elevations(stop_array=stop_array_y3, elevations=elevations)
 
-        # Plot to describe new "bumped" elevations
-
-        x5 = np.arange(0.0, len(modified_elevations), 1)
-        y5 = np.array(modified_elevations)
-        ax5.plot(x5, y5)
-        ax5.set_xlabel('time (s)')
-        ax5.set_ylabel('Elevations (adjusted)')
-        ax5.grid()
-
         if show_plot:
+            # Boolean array to describe charging time vs driving time (0 - charging, 1 - charging)
+            x1 = np.arange(0.0, len(not_charge), 1)
+            y1 = np.array(not_charge)
+
+            # Boolean array to describe day vs night (0 - night, 1 - day)
+
+            x2 = np.arange(0.0, len(not_day), 1)
+            y2 = np.array(not_day)
+
+            x3 = np.arange(0.0, len(stop_array_y3), 1)
+
+            x4 = np.arange(0.0, len(elevations), 1)
+
+            fig, (ax1, ax2, ax3, ax4, ax5) = plt.subplots(5, 1, figsize=(12, 12))
+            fig.suptitle('Elevation bumping plots')
+
+            # Plot to describe time driving
+
+            ax1.plot(x1, y1)
+            ax1.set_xlabel('time (s)')
+            ax1.set_ylabel('Driving?')
+            ax1.grid()
+
+            # Plot to describe daytime
+
+            ax2.plot(x2, y2)
+            ax2.set_xlabel('time (s)')
+            ax2.set_ylabel('Daytime?')
+            ax2.grid()
+
+            # Plot to describe time in motion
+
+            ax3.plot(x3, stop_array_y3)
+            ax3.set_xlabel('time (s)')
+            ax3.set_ylabel('In Motion?')
+            ax3.grid()
+
+            # Plot to describe elevations without adjustment for race hours
+
+            ax4.plot(x4, elevations)
+            ax4.set_xlabel('time (s)')
+            ax4.set_ylabel('Elevations (not adjusted)')
+            ax4.grid()
+
+            # Plot to describe new "bumped" elevations
+
+            x5 = np.arange(0.0, len(modified_elevations), 1)
+            y5 = np.array(modified_elevations)
+            ax5.plot(x5, y5)
+            ax5.set_xlabel('time (s)')
+            ax5.set_ylabel('Elevations (adjusted)')
+            ax5.grid()
+
             plt.show()
 
         return modified_elevations

--- a/simulation/environment/GIS.py
+++ b/simulation/environment/GIS.py
@@ -8,6 +8,7 @@ import polyline
 import requests
 import datetime
 import pytz
+from matplotlib import pyplot as plt
 from timezonefinder import TimezoneFinder
 from tqdm import tqdm
 
@@ -411,6 +412,111 @@ class GIS:
         self.path_time_zones = self.calculate_time_zones(self.path)
 
         return self.path
+
+    def elevation_bumping_plots(self, not_charge, not_day, elevations, show_plot=True):
+
+        # Boolean array to describe charging time vs driving time (0 - charging, 1 - charging)
+        x1 = np.arange(0.0, len(not_charge), 1)
+        y1 = np.array(not_charge)
+
+        # Boolean array to describe day vs night (0 - night, 1 - day)
+
+        x2 = np.arange(0.0, len(not_day), 1)
+        y2 = np.array(not_day)
+
+        # Create a stop array to describe motion when the car is not charging and day time
+
+        stop_array_y3 = np.logical_and(not_day, not_charge)
+        x3 = np.arange(0.0, len(stop_array_y3), 1)
+
+        x4 = np.arange(0.0, len(elevations), 1)
+
+        fig, (ax1, ax2, ax3, ax4, ax5) = plt.subplots(5, 1, figsize=(12, 12))
+        fig.suptitle('Elevation bumping plots')
+
+        # Plot to describe time driving
+
+        ax1.plot(x1, y1)
+        ax1.set_xlabel('time (s)')
+        ax1.set_ylabel('Driving?')
+        ax1.grid()
+
+        # Plot to describe daytime
+
+        ax2.plot(x2, y2)
+        ax2.set_xlabel('time (s)')
+        ax2.set_ylabel('Daytime?')
+        ax2.grid()
+
+        # Plot to describe time in motion
+
+        ax3.plot(x3, stop_array_y3)
+        ax3.set_xlabel('time (s)')
+        ax3.set_ylabel('In Motion?')
+        ax3.grid()
+
+        # Plot to describe elevations without adjustment for race hours
+
+        ax4.plot(x4, elevations)
+        ax4.set_xlabel('time (s)')
+        ax4.set_ylabel('Elevations (not adjusted)')
+        ax4.grid()
+
+        # Perform elevation "bumping" operation
+
+        modified_elevations = self.bump_elevations(stop_array=stop_array_y3, elevations=elevations)
+
+        # Plot to describe new "bumped" elevations
+
+        x5 = np.arange(0.0, len(modified_elevations), 1)
+        y5 = np.array(modified_elevations)
+        ax5.plot(x5, y5)
+        ax5.set_xlabel('time (s)')
+        ax5.set_ylabel('Elevations (adjusted)')
+        ax5.grid()
+
+        if show_plot:
+            plt.show()
+
+        return modified_elevations
+
+    @staticmethod
+    def bump_elevations(stop_array, elevations, verbose=False):
+        """
+
+        Args:
+            stop_array: An array describing the time in motion and the time stopping.
+                This is obtained by performing a logical AND operator on the boolean arrays describing day/night time
+                and charging hours. The ANDed result describes the car in motion for the following reason:
+                    - the day/night time array (called "not_day") uses 1 as day and 0 as night
+                    - the charging array (called "not_charge") uses 1 as in motion and 0 as charging
+                Thus the ANDed result describes the time tha car is not charging during the daytime. This is the time in motion.
+            elevations: An array of elevations based on closest_gis_indicies that has not been adjusted based on race timings (charging and daytime).
+
+        Returns: A "bumped" array of elevations that is adjusted for the time that the car does not move.
+
+        """
+
+        run_values, run_starts, run_lengths = helpers.find_runs(stop_array)
+
+        array_slices = []
+        working_index = 0
+
+        for i in range(0, len(run_values)):
+            if verbose:
+                print(
+                    f"There is a {run_values[i]} run from index {run_starts[i]} to index {run_lengths[i] + run_starts[i]}."
+                    f" The length is {run_lengths[i]}")
+            if not run_values[i]:
+                elevation_slice = np.array([elevations[working_index]] * run_lengths[i])
+                working_index += 1
+            else:
+                elevation_slice = elevations[working_index:run_lengths[i] + working_index]
+            array_slices.append(elevation_slice)
+
+        modified_elevations = np.concatenate(array_slices)
+
+        return modified_elevations[0:len(elevations)]
 
 
 if __name__ == "__main__":

--- a/simulation/main/MainSimulation.py
+++ b/simulation/main/MainSimulation.py
@@ -47,7 +47,7 @@ class Simulation:
             settings_path = settings_directory / "settings_ASC.json"
         else:
             settings_path = settings_directory / "settings_FSGP.json"
-
+        
         # ----- Load arguments -----
         with open(settings_path) as f:
             args = json.load(f)
@@ -209,15 +209,18 @@ class Simulation:
 
     @helpers.timeit
     def optimize(self, *args, **kwargs):
+        guess_lower_bound = 20
+        guess_upper_bound = 80
+
         bounds = {
-            'x0': (20, 80),
-            'x1': (20, 80),
-            'x2': (20, 80),
-            'x3': (20, 80),
-            'x4': (20, 80),
-            'x5': (20, 80),
-            'x6': (20, 80),
-            'x7': (20, 80),
+            'x0': (guess_lower_bound, guess_upper_bound),
+            'x1': (guess_lower_bound, guess_upper_bound),
+            'x2': (guess_lower_bound, guess_upper_bound),
+            'x3': (guess_lower_bound, guess_upper_bound),
+            'x4': (guess_lower_bound, guess_upper_bound),
+            'x5': (guess_lower_bound, guess_upper_bound),
+            'x6': (guess_lower_bound, guess_upper_bound),
+            'x7': (guess_lower_bound, guess_upper_bound),
         }
 
         # https://github.com/fmfn/BayesianOptimization
@@ -235,7 +238,7 @@ class Simulation:
         speed_result = np.empty(len(result_params))
         for i in range(len(speed_result)):
             speed_result[i] = result_params[i]
-
+        
         speed_result = helpers.reshape_and_repeat(speed_result, self.simulation_duration)
         speed_result = np.insert(speed_result, 0, 0)
 
@@ -344,7 +347,7 @@ class Simulation:
 
         # Get the wind speeds at every location
         wind_speeds = get_array_directional_wind_speed(gis_vehicle_bearings, absolute_wind_speeds,
-                                                       wind_directions)
+                                                                    wind_directions)
 
         # Get an array of solar irradiance at every coordinate and time
         solar_irradiances = self.solar_calculations.calculate_array_GHI(self.route_coords[closest_gis_indices],
@@ -356,6 +359,8 @@ class Simulation:
 
         # Implementing day start/end charging (Charge from 7am-9am and 6pm-8pm) for ASC and
         # (Charge from 8am-9am and 6pm-8pm) for FSGP
+        # ASC: 13 Hours of Race Day, 9 Hours of Driving
+
         # Ensuring Car does not move at night
         bool_lis = []
         night_lis = []

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -10,3 +10,24 @@ def test_checkForNonConsecutiveZeros():
         (helpers.checkForNonConsecutiveZeros(test_array_true), helpers.checkForNonConsecutiveZeros(test_array_false)))
 
     assert result == (True, False)
+
+
+def test_find_runs1():
+    """
+    Unit test for helpers.find_runs(x). Tests if it can identify small examples of runs in a small array
+    """
+    input_array = np.array([1, 1, 3, 4, 4, 4, 4])
+    expected_output_run_values = np.array([1, 3, 4])
+    expected_output_run_starts = np.array([0, 2, 3])
+    expected_output_run_lengths = np.array([2, 1, 4])
+
+    test_output_run_values, test_output_run_starts, test_output_run_lengths = helpers.find_runs(input_array)
+
+    assert (expected_output_run_values == test_output_run_values).all()
+    assert (expected_output_run_starts == test_output_run_starts).all()
+    assert (expected_output_run_lengths == test_output_run_lengths).all()
+
+
+if __name__ == "__main__":
+    test_find_runs1()
+    test_checkForNonConsecutiveZeros()


### PR DESCRIPTION
This is a feature that properly shifts the elevation array values to match up with when the car is allowed to drive/not allowed to drive.

Before: Elevation array changes despite the race not starting. The following graph has a `start_hour = 7`. Over `t = 0` to `t = 2`, Distances and Delta Energy show no movement in the car.  However, elevations change as time passes. This is the issue I aimed to solve.

![image](https://user-images.githubusercontent.com/64388914/124377896-53c19280-dc63-11eb-966a-b00b7ad1dfda.png)

Note: Speed array shows the car is moving, but this is a small error. I've verified that in the background the speed array follows the race timings. This means that the speed array is 0 when the car is not allowed to move and some other speed when the car is allowed to move.

After: This is the final result. I perform what I call a "bump" operation on the elevation array. Notice that the elevation array in this graph is the same as the previous ones, but only differs in that it is offset by the amount of time the car isn't moving. In this case, from `t = 0` to `t = 2`, the elevations are "frozen". Similar behaviour can be seen at the end of the simulation time from `t = 11` to `t = 12`. This is when the driving day ends.

![final_plot_w_bumped_elevations](https://user-images.githubusercontent.com/64388914/124377931-97b49780-dc63-11eb-95f2-83df259a0c6a.png)
