### PR TITLE
Speed Array Constraints - Response to Issue #63

### DIFF
--- a/examples/max_distance_from_speed_using_arrays.py
+++ b/examples/max_distance_from_speed_using_arrays.py
@@ -10,7 +10,9 @@ before the battery runs out [speed -> distance].
 
 @helpers.timeit
 def main():
-    input_speed = np.array([35] * 12)
+
+    # indicates a constant speed of 35km/h throughout the simulation
+    input_speed = np.array([35])
 
     """
     Note: it no longer matters how many elements the input_speed array has, the simulation automatically
@@ -41,6 +43,7 @@ def main():
     print(f'Speeds array: {optimized["params"]}')
 
     return distance_travelled
+
 
 if __name__ == "__main__":
     main()

--- a/simulation/main/MainSimulation.py
+++ b/simulation/main/MainSimulation.py
@@ -316,6 +316,7 @@ class Simulation:
         path_distances = self.gis.path_distances
         cumulative_distances = np.cumsum(path_distances)  # [cumulative_distances] = meters
 
+        # TODO: integrate verbose graphing behaviour into self.__plot_graph() method
         if verbose:
             fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2, 2, sharex=True, figsize=(12, 20))
 

--- a/simulation/main/MainSimulation.py
+++ b/simulation/main/MainSimulation.py
@@ -276,7 +276,7 @@ class Simulation:
         plt.tight_layout()
         plt.show()
 
-    def __run_simulation_calculations(self, speed_kmh, verbose=False):
+    def __run_simulation_calculations(self, speed_kmh, verbose=True):
         """
         Helper method to perform all calculations used in run_model. Returns a SimulationResult object 
         containing members that specify total distance travelled and time taken at the end of the simulation
@@ -510,8 +510,6 @@ class Simulation:
             ax1.set_xlabel('time (s)')
             ax1.set_ylabel('Speed (km/h)')
             ax1.grid()
-
-            speed_kmh = np.logical_and(speed_kmh, state_of_charge) * speed_kmh
 
             # Plot state of charge and speed array after ANDed with state of charge
 

--- a/simulation/main/MainSimulation.py
+++ b/simulation/main/MainSimulation.py
@@ -124,7 +124,7 @@ class Simulation:
         self.timestamps = np.arange(0, self.simulation_duration + self.tick, self.tick)
 
     @helpers.timeit
-    def run_model(self, speed=np.array([20, 20, 20, 20, 20, 20, 20, 20]), plot_results=True, **kwargs):
+    def run_model(self, speed=np.array([20, 20, 20, 20, 20, 20, 20, 20]), plot_results=True, verbose=False, **kwargs):
         """
         Updates the model in tick increments for the entire simulation duration. Returns
         a final battery charge and a distance travelled for this duration, given an
@@ -164,7 +164,7 @@ class Simulation:
 
         # ------ Run calculations and get result and modified speed array -------
 
-        result, speed_kmh = self.__run_simulation_calculations(speed_kmh, verbose=False)
+        result, speed_kmh = self.__run_simulation_calculations(speed_kmh, verbose=verbose)
 
         # ------- Parse results ---------
         simulation_arrays = result.arrays
@@ -624,6 +624,3 @@ class Simulation:
         self.local_times = local_times
 
         return results, speed_kmh
-
-
-

--- a/simulation/main/MainSimulation.py
+++ b/simulation/main/MainSimulation.py
@@ -13,7 +13,7 @@ from simulation.common import helpers
 from simulation.config import settings_directory
 from simulation.main.SimulationResult import SimulationResult
 
-from simulation.common.helpers import adjust_timestamps_to_local_times, get_array_directional_wind_speed, find_runs
+from simulation.common.helpers import adjust_timestamps_to_local_times, get_array_directional_wind_speed
 
 
 class Simulation:
@@ -48,7 +48,6 @@ class Simulation:
         else:
             settings_path = settings_directory / "settings_FSGP.json"
 
-        # ----- Load arguments -----
         with open(settings_path) as f:
             args = json.load(f)
 
@@ -117,7 +116,7 @@ class Simulation:
         weather_hour = helpers.hour_from_unix_timestamp(self.weather.last_updated_time)
         self.time_of_initialization = self.weather.last_updated_time + 3600 * (24 + self.start_hour - weather_hour)
 
-        self.solar_calculations = simulation.SolarCalculations()  # Race-Independent
+        self.solar_calculations = simulation.SolarCalculations()  # Race-independent
 
         self.local_times = 0
 
@@ -414,7 +413,7 @@ class Simulation:
         # (Charge from 8am-9am and 6pm-8pm) for FSGP
         # ASC: 13 Hours of Race Day, 9 Hours of Driving
 
-        # Ensuring Car does not move at night
+        # Ensuring car does not move at night
         bool_lis = []
         night_lis = []
         if self.race_type == "FSGP":


### PR DESCRIPTION
These commits apply timing constraints to the optimized speed array, then apply acceleration to the speed array. This is a response to #63. Here are the results:

![optimized_array](https://user-images.githubusercontent.com/64388914/126047923-192d34e9-127d-4c85-910b-e9a103f79df3.png)

This simulation was run starting at 7 AM for ASC, whose driving time starts at 9 AM and ends at 6 PM. The optimizer was set to have 5 init points and 10 iterations done. Not the best, but I wanted these results fast. I blame the less-than-ideal results on the poor optimizer settings.

These commits also correctly display the speed array with timing constraints in place for the first time the graphs show up. See the following:
![first_pass_const](https://user-images.githubusercontent.com/64388914/126047831-0871255f-9e95-43dd-ba13-1fd6a0108440.png)

   