### PR TITLE
Refactoring acceleration

### DIFF
--- a/simulation/common/helpers.py
+++ b/simulation/common/helpers.py
@@ -84,36 +84,7 @@ def reshape_and_repeat(input_array, reshape_length):
         return result
 
 
-def add_acceleration(input_array, acceleration):
-    """
-    Takes in the speed array with sudden speed changes and an acceleration scalar,
-    return a speed array with constant acceleration / deceleration
-    :param input_array: (int[N]) input speed array (km/h)
-    :param acceleration: (int) acceleration (km/h^2)
-    :return:speed array with acceleration (int[N])
-    """
-
-    input_array = input_array.astype(float)
-    array_diff = np.diff(input_array)
-    array_index = np.where(array_diff != 0)
-
-    # acceleration per second (kmh/s)
-    acceleration = abs(acceleration) / 3600
-
-    for i in array_index[0]:
-        # check if accelerate or decelerate
-        if array_diff[i] > 0:
-            while input_array[i] < input_array[i + 1] and i + 1 < len(input_array) - 1:
-                # print("i'm stuck in this if while loop")
-                input_array[i + 1] = input_array[i] + acceleration
-                i += 1
-
-        else:
-            while input_array[i] > input_array[i + 1] and i + 1 < len(input_array) - 1:
-                # print("i'm stuck in this else while loop")
-                input_array[i + 1] = input_array[i] - acceleration
-                i += 1
-
+def apply_deceleration(input_array, acceleration):
     return input_array
 
 

--- a/simulation/common/helpers.py
+++ b/simulation/common/helpers.py
@@ -84,8 +84,70 @@ def reshape_and_repeat(input_array, reshape_length):
         return result
 
 
-def apply_deceleration(input_array, acceleration):
-    return input_array
+def generate_deceleration_array(initial_velocity, final_velocity, deceleration_interval):
+    """
+    Create an array where each element represents a step in the deceleration from initial_velocity to final_velocity.
+
+    :param initial_velocity: the velocity at which deceleration occurs for the first time (km/h)
+    :param final_velocity: the target velocity that is being decelerated to (km/h)
+    :param deceleration_interval: the time it will take to decelerate from initial velocity to final velocity (s)
+    :return: an array of the velocities between initial_velocity and final_velocity
+    """
+    deceleration_instance_size = (final_velocity + initial_velocity) / (deceleration_interval + 1)
+    return np.arange(initial_velocity, final_velocity, -deceleration_instance_size)[1:]
+
+
+def apply_deceleration(input_speed_array, deceleration_interval):
+    """
+    Replace instances of instant deceleration in a velocity array with uniform changes in velocity that are spread
+    over the deceleration_interval.
+
+    The distance travelled by the simulation will be reduced by a negligible amount.
+
+    :param input_speed_array: the velocity array (km/h)
+    :param deceleration_interval: the duration of the deceleration intervals (s)
+    :return: a speed array with uniform deceleration (km/h)
+    """
+    if input_speed_array is None:
+        return np.array([])
+    if deceleration_interval <= 0:
+        return input_speed_array
+
+    input_speed_array = input_speed_array.astype(float)
+    acceleration_instances = np.diff(input_speed_array, prepend=[0])  # Prepending 0 to align acceleration_instances
+    # array with speed_array
+    deceleration_instances = np.where(acceleration_instances < 0)[0]  # [0] must be added because np.where returns an
+    # array with only one element
+
+    for idx in deceleration_instances:
+        initial_velocity = input_speed_array[idx - 1]
+        final_velocity = input_speed_array[idx]
+
+        if is_valid_speed_array(deceleration_interval, idx, initial_velocity, input_speed_array):
+            deceleration_array = generate_deceleration_array(initial_velocity, final_velocity, deceleration_interval)
+            input_speed_array[idx - deceleration_interval:idx] = deceleration_array
+    return input_speed_array
+
+
+def is_valid_speed_array(deceleration_interval, idx, initial_velocity, input_speed_array):
+    """
+    Check that the specified speed array is valid in relation to the chosen deceleration interval.
+
+    :param deceleration_interval: the duration of the deceleration intervals (s)
+    :param idx: the index used to check our deceleration interval
+    :param initial_velocity: the velocity at the beginning of the deceleration period
+    :param input_speed_array: the speed array
+    :return: True if the array is valid, False if it is not
+    """
+    if deceleration_interval > len(input_speed_array) - 1:  # Check that the speed array isn't smaller than the
+        # deceleration interval
+        return False
+
+    for i in range(0, deceleration_interval):  # Check that the speed is constant over the deceleration interval
+        if initial_velocity != input_speed_array[idx - i - 1]:
+            return False
+    return True
+
 
 
 def hour_from_unix_timestamp(unix_timestamp):

--- a/simulation/main/MainSimulation.py
+++ b/simulation/main/MainSimulation.py
@@ -159,7 +159,7 @@ class Simulation:
 
         speed_kmh = helpers.reshape_and_repeat(speed, self.simulation_duration)
         speed_kmh = np.insert(speed_kmh, 0, 0)
-        speed_kmh = helpers.add_acceleration(speed_kmh, 500)
+        speed_kmh = helpers.apply_deceleration(speed_kmh, 20)
 
         # ------ Run calculations and get result and modified speed array -------
 
@@ -343,8 +343,8 @@ class Simulation:
                 helpers.plot_graph(self.timestamps, [speed_kmh_without_checkpoints, speed_kmh],
                                    ["Speed before waypoints", " Speed after waypoints"],
                                    "Before and After waypoints")
-        # Acceleration currently is broken and I'm not sure why. Have to take another look at this soon.
-        # speed_kmh = helpers.add_acceleration(speed_kmh, 500)
+
+        speed_kmh = helpers.apply_deceleration(speed_kmh, 20)
 
         # ----- Expected distance estimate -----
 

--- a/tests/test_deceleration.py
+++ b/tests/test_deceleration.py
@@ -1,0 +1,119 @@
+import math
+import unittest
+
+import numpy as np
+
+from simulation.common import helpers
+from simulation.common.helpers import *
+
+
+def test_no_deceleration():
+    test_speed_array = np.array([50, 50, 50, 50, 50, 50, 50, 50])
+
+    result_speed_array = apply_deceleration(test_speed_array, 3)
+
+    expected_speed_array = np.array([50, 50, 50, 50, 50, 50, 50, 50])
+    assert np.all(result_speed_array == expected_speed_array)
+
+def test_no_deceleration_2(self):
+    test_speed_array = np.array([0, 0, 0, 0, 0, 0, 0, 0])
+
+    result_speed_array = apply_deceleration(test_speed_array, 3)
+
+    expected_speed_array = np.array([0, 0, 0, 0, 0, 0, 0, 0])
+    assert np.all(result_speed_array == expected_speed_array)
+
+def test_acceleration(self):
+    test_speed_array = np.array([10, 20, 30, 40, 50, 60, 70, 80])
+
+    result_speed_array = apply_deceleration(test_speed_array, 3)
+
+    expected_speed_array = np.array([10, 20, 30, 40, 50, 60, 70, 80])
+    assert np.all(result_speed_array == expected_speed_array)
+
+def test_trivial(self):
+    test_speed_array = np.array([50, 50, 50, 50, 0, 0, 0, 0])
+
+    result_speed_array = apply_deceleration(test_speed_array, 3)
+
+    expected_speed_array = np.array([50, 37.5, 25, 12.5, 0, 0, 0, 0])
+    assert np.all(result_speed_array == expected_speed_array)
+
+def test_trivial_2(self):
+    test_speed_array = np.array([40, 44, 49.9, 50, 50, 50, 50, 0, 0, 0, 0])
+
+    result_speed_array = apply_deceleration(test_speed_array, 3)
+
+    expected_speed_array = np.array([40, 44, 49.9, 50, 37.5, 25, 12.5, 0, 0, 0, 0])
+    assert np.all(result_speed_array == expected_speed_array)
+
+def test_trivial_3(self):
+    test_speed_array = np.array([50, 50, 50, 50, 0, 0, 50, 0])
+
+    result_speed_array = apply_deceleration(test_speed_array, 3)
+
+    expected_speed_array = np.array([50, 37.5, 25, 12.5, 0, 0, 50, 0])
+    assert np.all(result_speed_array == expected_speed_array)
+
+
+def test_negative_steps(self):
+    test_speed_array = np.array([50, 50, 50, 50, 0, 0, 0, 0])
+
+    test_interval = -3
+    result_speed_array = apply_deceleration(test_speed_array, test_interval)
+
+    expected_speed_array = np.array([50, 50, 50, 50, 0, 0, 0, 0])
+    assert np.all(result_speed_array == expected_speed_array)
+
+def test_none_array(self):
+    test_speed_array = None
+
+    test_interval = 123
+    result_speed_array = apply_deceleration(test_speed_array, test_interval)
+
+    expected_speed_array = np.array([])
+
+    assert np.all(result_speed_array == expected_speed_array)
+
+def test_huge_interval(self):
+    test_speed_array = np.array([50, 50, 50, 50, 0, 0, 50, 0])
+
+    test_interval = 123
+    result_speed_array = apply_deceleration(test_speed_array, test_interval)
+
+    expected_speed_array = np.array([50, 50, 50, 50, 0, 0, 50, 0])
+    assert np.all(result_speed_array == expected_speed_array)
+
+def test_interval_size_equal_array_size(self):
+    test_speed_array = np.array([50, 50, 0])
+
+    test_interval = 3
+    result_speed_array = apply_deceleration(test_speed_array, test_interval)
+
+    expected_speed_array = np.array([50, 50, 0])
+    assert np.all(result_speed_array == expected_speed_array)
+
+def test_large_interval_size(self):
+    a = np.full((1, 100), 50)[0]
+    test_speed_array = np.concatenate((a, 0), axis=None)
+
+    test_interval = 60
+    result_speed_array = apply_deceleration(test_speed_array, test_interval) # step size should be 50/61
+    steps = 0
+    test = True
+    for i in range(0, len(result_speed_array) - 1):
+        size = 50/61
+        if result_speed_array[i] != 50.0:
+            steps = steps + 1
+            if not (math.isclose(result_speed_array[i + 1], (result_speed_array[i] - size), rel_tol=1e-6)):
+                if result_speed_array[i + 1] == 0:
+                    break
+                test = False
+
+    if steps != test_interval:
+        test = False
+    assert test
+
+
+if __name__ == '__main__':
+    test_large_interval_size()


### PR DESCRIPTION
This pull request would fix the acceleration issues we've encountered. By altering the parameters of the `apply_deceleration()` method, we can now provide a time duration for all decelerations in the simulation.

We may improve on this later by making the deceleration interval a function (like a logarithmic function) of the velocities being decelerated to and from. We could do this once we've gotten a better understanding of how fast regenerative braking slows down the car.

Resolves #74, resolves #52 