### PR TITLE
Change to speed array such that each element now each represent one hour of driving time

### DIFF
--- a/simulation/common/helpers.py
+++ b/simulation/common/helpers.py
@@ -548,26 +548,26 @@ def apply_race_timing_constraints(speed_kmh, start_hour, simulation_duration, ra
     :param str race_type: A string describing the race type. Must be one of "ASC" or "FSGP"
     :param np.ndarray timestamps: A NumPy array representing the timestamps for the simulated race
     :param bool verbose: A flag to show speed array modifications for debugging purposes
-    :returns: constrained_speed_kmh, a speed array with race timing constraints applied to it, not_charge, a boolean array representing when the car can charge and when it cannot (1 = charge, 0 = not_charge)
+    :returns: constrained_speed_kmh, a speed array with race timing constraints applied to it, not_charging_array, a boolean array representing when the car can charge and when it cannot (1 = charge, 0 = not_charging_array)
     :rtype: np.ndarray
     :raises: ValueError is race_type is not one of "ASC" or "FSGP"
 
     """
 
-    not_charge = get_race_timing_constraints_boolean(start_hour, simulation_duration, race_type)
+    not_charging_array = get_race_timing_constraints_boolean(start_hour, simulation_duration, race_type)
 
     if verbose:
         plot_graph(timestamps=timestamps,
-                   arrays_to_plot=[not_charge, speed_kmh],
+                   arrays_to_plot=[not_charging_array, speed_kmh],
                    array_labels=["not charge", "updated speed (km/h)"],
                    graph_title="not charge and speed")
 
-    constrained_speed_kmh = np.logical_and(speed_kmh, not_charge) * speed_kmh
+    constrained_speed_kmh = np.logical_and(speed_kmh, not_charging_array) * speed_kmh
 
-    return constrained_speed_kmh, not_charge
+    return constrained_speed_kmh, not_charging_array
 
 
-def get_race_timing_constraints_boolean(start_hour, simulation_duration, race_type, as_seconds=True):
+def get_race_timing_constraints_boolean(start_hour, simulation_duration, race_type, granularity, as_seconds=True):
     """
 
     Applies regulation timing constraints to a speed array.
@@ -576,6 +576,7 @@ def get_race_timing_constraints_boolean(start_hour, simulation_duration, race_ty
     :param int simulation_duration: An integer representing simulation duration in seconds
     :param str race_type: A string describing the race type. Must be one of "ASC" or "FSGP"
     :param bool as_seconds: will return an array of seconds, or hours if set to False
+    :param float granularity: how granular the time divisions for Simulation's speed array should be, where 1 is hourly and 0.5 is twice per hour.
     :returns: driving_time_boolean, a boolean array with race timing constraints applied to it
     :rtype: np.ndarray
     :raises: ValueError is race_type is not one of "ASC" or "FSGP"
@@ -585,7 +586,7 @@ def get_race_timing_constraints_boolean(start_hour, simulation_duration, race_ty
     # (Charge from 7am-9am and 6pm-8pm) for ASC - 13 Hours of Race Day, 9 Hours of Driving
     # (Charge from 8am-9am and 6pm-8pm) for FSGP
 
-    simulation_hours = np.arange(start_hour, start_hour + simulation_duration / (60 * 60))
+    simulation_hours = np.arange(start_hour, start_hour + simulation_duration / (60 * 60), (1.0 / granularity))
 
     if as_seconds is True:
         simulation_hours_by_second = np.append(np.repeat(simulation_hours, 3600), start_hour + simulation_duration / (60 * 60)).astype(int)
@@ -852,7 +853,6 @@ def map_array_to_targets(input_array, target_array):
 
 if __name__ == '__main__':
     out = map_array_to_targets([90, 60, 10], [0, 1, 1, 1, 0])
-    print(out)
 
     # speed_array input
     speed_array = np.array([45, 87, 65, 89, 43, 54, 45, 23, 34, 20])

--- a/simulation/common/helpers.py
+++ b/simulation/common/helpers.py
@@ -575,7 +575,7 @@ def get_race_timing_constraints_boolean(start_hour, simulation_duration, race_ty
     :param int start_hour: An integer representing the race's start hour
     :param int simulation_duration: An integer representing simulation duration in seconds
     :param str race_type: A string describing the race type. Must be one of "ASC" or "FSGP"
-    :param str time: return array where an element represents an hour or a second
+    :param bool as_seconds: will return an array of seconds, or hours if set to False
     :returns: driving_time_boolean, a boolean array with race timing constraints applied to it
     :rtype: np.ndarray
     :raises: ValueError is race_type is not one of "ASC" or "FSGP"
@@ -667,7 +667,7 @@ def plot_graph(timestamps, arrays_to_plot, array_labels, graph_title, save=True)
     return
 
 
-def route_visualization(coords, visible=True):
+def route_visualization(coords, visible=True):  # TODO: Consolidate this with Plotting module
     """
 
     Takes in a list of coordinates and visualizes them using MapBox.

--- a/simulation/common/helpers.py
+++ b/simulation/common/helpers.py
@@ -602,6 +602,41 @@ def get_race_timing_constraints_boolean(start_hour, simulation_duration, race_ty
     return np.invert(np.logical_or.reduce(driving_time_boolean))
 
 
+def get_charge_timing_constraints_boolean(start_hour, simulation_duration, race_type, as_seconds=True):
+    """
+
+    Applies regulation timing constraints to an array representing when the car will be able to charge.
+
+    :param int start_hour: An integer representing the race's start hour
+    :param int simulation_duration: An integer representing simulation duration in seconds
+    :param str race_type: A string describing the race type. Must be one of "ASC" or "FSGP"
+    :param bool as_seconds: will return an array of seconds, or hours if set to False
+    :returns: driving_time_boolean, a boolean array with charge timing constraints applied to it
+    :rtype: np.ndarray
+    :raises: ValueError is race_type is not one of "ASC" or "FSGP"
+
+    """
+
+    # (Charge from 7am-9am and 6pm-8pm) for ASC - 13 Hours of Race Day, 9 Hours of Driving
+    # (Charge from 8am-9am and 6pm-8pm) for FSGP
+
+    simulation_hours = np.arange(start_hour, start_hour + simulation_duration / (60 * 60))
+
+    if as_seconds is True:
+        simulation_hours_by_second = np.append(np.repeat(simulation_hours, 3600), start_hour + simulation_duration / (60 * 60)).astype(int)
+        if race_type == "ASC":
+            driving_time_boolean = [(simulation_hours_by_second % 24) <= 7, (simulation_hours_by_second % 24) >= 20]
+        else:  # FSGP
+            driving_time_boolean = [(simulation_hours_by_second % 24) <= 8, (simulation_hours_by_second % 24) >= 20]
+    else:
+        if race_type == "ASC":
+            driving_time_boolean = [(simulation_hours % 24) <= 7, (simulation_hours % 24) >= 20]
+        else:  # FSGP
+            driving_time_boolean = [(simulation_hours % 24) <= 8, (simulation_hours % 24) >= 20]
+
+    return np.invert(np.logical_or.reduce(driving_time_boolean))
+
+
 def plot_graph(timestamps, arrays_to_plot, array_labels, graph_title, save=True):
     """
 

--- a/simulation/common/helpers.py
+++ b/simulation/common/helpers.py
@@ -590,14 +590,14 @@ def get_race_timing_constraints_boolean(start_hour, simulation_duration, race_ty
     if as_seconds is True:
         simulation_hours_by_second = np.append(np.repeat(simulation_hours, 3600), start_hour + simulation_duration / (60 * 60)).astype(int)
         if race_type == "ASC":
-            driving_time_boolean = [(simulation_hours_by_second % 24) <= 7, (simulation_hours_by_second % 24) >= 18]
+            driving_time_boolean = [(simulation_hours_by_second % 24) <= 9, (simulation_hours_by_second % 24) >= 18]
         else:  # FSGP
-            driving_time_boolean = [(simulation_hours_by_second % 24) <= 8, (simulation_hours_by_second % 24) >= 18]
+            driving_time_boolean = [(simulation_hours_by_second % 24) <= 9, (simulation_hours_by_second % 24) >= 18]
     else:
         if race_type == "ASC":
-            driving_time_boolean = [(simulation_hours % 24) <= 7, (simulation_hours % 24) >= 18]
+            driving_time_boolean = [(simulation_hours % 24) <= 9, (simulation_hours % 24) >= 18]
         else:  # FSGP
-            driving_time_boolean = [(simulation_hours % 24) <= 8, (simulation_hours % 24) >= 18]
+            driving_time_boolean = [(simulation_hours % 24) <= 9, (simulation_hours % 24) >= 18]
 
     return np.invert(np.logical_or.reduce(driving_time_boolean))
 

--- a/simulation/main/Simulation.py
+++ b/simulation/main/Simulation.py
@@ -205,11 +205,9 @@ class Simulation:
         speed_mapped_kmh = np.insert(speed_mapped_kmh, 0, 0)
         speed_kmh = helpers.apply_deceleration(speed_mapped_kmh, 20)
 
-        _, not_charge = helpers.apply_race_timing_constraints(speed_kmh=speed_kmh, start_hour=self.start_hour,
-                                                              simulation_duration=self.simulation_duration,
-                                                              race_type=self.race_type,
-                                                              timestamps=self.timestamps,
-                                                              verbose=verbose)
+        not_charge = helpers.get_charge_timing_constraints_boolean(start_hour=self.start_hour,
+                                                                   simulation_duration=self.simulation_duration,
+                                                                   race_type=self.race_type)
 
         if self.race_type == "ASC":
             speed_kmh_without_checkpoints = speed_kmh
@@ -376,7 +374,7 @@ class Simulation:
 
         # Get the wind speeds at every location
         wind_speeds = helpers.get_array_directional_wind_speed(gis_vehicle_bearings, absolute_wind_speeds,
-                                                       wind_directions)
+                                                               wind_directions)
 
         pbar.update(1)
 
@@ -385,6 +383,7 @@ class Simulation:
                                                                         time_zones, local_times,
                                                                         gis_route_elevations_at_each_tick,
                                                                         cloud_covers)
+
 
         pbar.update(2)
         # TLDR: we have now obtained solar irradiances, wind speeds, and gradients at each tick
@@ -397,7 +396,7 @@ class Simulation:
         motor_consumed_energy = self.basic_motor.calculate_energy_in(speed_kmh, gradients, wind_speeds, self.tick)
         array_produced_energy = self.basic_array.calculate_produced_energy(solar_irradiances, self.tick)
 
-        motor_consumed_energy = np.logical_and(motor_consumed_energy, not_charge) * motor_consumed_energy
+        array_produced_energy = np.logical_and(array_produced_energy, not_charge) * array_produced_energy
 
         pbar.update(1)
 

--- a/simulation/main/Simulation.py
+++ b/simulation/main/Simulation.py
@@ -423,6 +423,9 @@ class Simulation:
         state_of_charge = battery_variables_array[0]
         state_of_charge[np.abs(state_of_charge) < 1e-03] = 0
 
+        # This functionality may want to be removed in the future (speed array gets mangled when SOC <= 0)
+        speed_kmh = np.logical_and(not_charge, state_of_charge) * speed_kmh
+
         if verbose:
             indices_and_environment_graph = Graph([temp, closest_gis_indices, closest_weather_indices, gradients,
                                                    time_zones, gis_vehicle_bearings],

--- a/simulation/main/Simulation.py
+++ b/simulation/main/Simulation.py
@@ -483,6 +483,14 @@ class Simulation:
 
         return results
 
-    def get_driving_hours(self):
+    def get_driving_hours(self) -> int:
+        """
+
+        Returns the number of hours that the car is permitted to be driving.
+        Dependent on rules in get_race_timing_constraints_boolean() function in common/helpers.
+
+        :return: number of hours as an integer
+        """
+
         return helpers.get_race_timing_constraints_boolean(self.start_hour, self.simulation_duration,
                                                            self.race_type, as_seconds=False).astype(int).sum()

--- a/simulation/main/Simulation.py
+++ b/simulation/main/Simulation.py
@@ -200,13 +200,12 @@ class Simulation:
 
         speed_kmh = helpers.reshape_and_repeat(speed, self.simulation_duration)
         speed_kmh = np.insert(speed_kmh, 0, 0)
-        speed_kmh = helpers.apply_deceleration(speed_kmh, 20)
-
         speed_kmh, not_charge = helpers.apply_race_timing_constraints(speed_kmh=speed_kmh, start_hour=self.start_hour,
                                                                       simulation_duration=self.simulation_duration,
                                                                       race_type=self.race_type,
                                                                       timestamps=self.timestamps,
                                                                       verbose=verbose)
+        speed_kmh = helpers.apply_deceleration(speed_kmh, 20)
 
         if self.race_type == "ASC":
             speed_kmh_without_checkpoints = speed_kmh

--- a/simulation/run_simulation.py
+++ b/simulation/run_simulation.py
@@ -22,12 +22,13 @@ class SimulationSettings:
     This class stores settings that will be used by the simulation.
 
     """
-    def __init__(self, golang=True, return_type=SimulationReturnType.distance_travelled, optimization_iterations=5, route_visualization=False, verbose=False):
+    def __init__(self, golang=True, return_type=SimulationReturnType.distance_travelled, optimization_iterations=5, route_visualization=False, verbose=False, granularity=1):
         self.optimization_iterations = optimization_iterations
         self.golang = golang
         self.return_type = return_type
         self.route_visualization = route_visualization
         self.verbose = verbose
+        self.granularity = granularity
 
 
 def run_simulation(simulation_settings):
@@ -54,8 +55,10 @@ def run_simulation(simulation_settings):
     # Initialize simulation model
     simulation_model = Simulation(initial_simulation_conditions, simulation_settings.return_type,
                                   race_type="ASC",
-                                  golang=simulation_settings.golang)
-    driving_hours = simulation_model.get_driving_hours()
+                                  golang=simulation_settings.golang,
+                                  granularity=simulation_settings.granularity)
+
+    driving_hours = simulation_model.get_driving_time_divisions()
     input_speed = np.array([30] * driving_hours)
 
     # Run simulation model with a "guess" speed array
@@ -156,15 +159,19 @@ def display_commands():
           "                      execute as verbose.\n"
           "                      (True/False)\n"
           "\n"                  
-          "route-visualization   Define whether the simulation route\n"
+          "-route-visualization   Define whether the simulation route\n"
           "                      should be plotted and visualized.\n"
           "                      (True/False)\n"
-          "\n"     
+          "\n"
+          "-granularity          Define how granular the speed array\n"
+          "                      should be, where 1 is hourly and 2 is\n"
+          "                      bi-hourly.\n"
+          "\n"
           "-------------------------USAGE--------------------------\n"
           ">>>python3 run_simulation.py -golang=False -optimize=time_taken -iter=3\n")
 
 
-valid_commands = ["-help", "-golang", "-optimize", "-iter", "-verbose", "-route-visualization"]
+valid_commands = ["-help", "-golang", "-optimize", "-iter", "-verbose", "-route-visualization", "-granularity"]
 
 
 def identify_invalid_commands(cmds):
@@ -237,6 +244,9 @@ def parse_commands(cmds):
 
         elif split_cmd[0] == '-route-visualization':
             simulation_settings.route_visualization = True if split_cmd[1] == 'True' else False
+
+        elif split_cmd[0] == '-granularity':
+            simulation_settings.granularity = split_cmd[1]
 
     return simulation_settings
 

--- a/simulation/run_simulation.py
+++ b/simulation/run_simulation.py
@@ -42,8 +42,6 @@ def run_simulation(simulation_settings):
 
     """
 
-    input_speed = np.array([30])
-
     #  ----- Parse initial conditions ----- #
 
     with open(settings_directory / "initial_conditions.json") as f:
@@ -56,11 +54,15 @@ def run_simulation(simulation_settings):
     simulation_model = Simulation(initial_simulation_conditions, simulation_settings.return_type,
                                   race_type="ASC",
                                   golang=simulation_settings.golang)
+    driving_hours = simulation_model.get_driving_hours()
+    input_speed = np.array([30] * driving_hours)
+
     unoptimized_time = simulation_model.run_model(speed=input_speed, plot_results=True,
                                                   verbose=simulation_settings.verbose,
                                                   route_visualization=simulation_settings.route_visualization)
+
     bounds = InputBounds()
-    bounds.add_bounds(8, 20, 60)
+    bounds.add_bounds(driving_hours, 20, 60)
     optimization = BayesianOptimization(bounds, simulation_model.run_model)
     random_optimization = RandomOptimization(bounds, simulation_model.run_model)
 

--- a/simulation/run_simulation.py
+++ b/simulation/run_simulation.py
@@ -51,26 +51,31 @@ def run_simulation(simulation_settings):
 
     #  ----- Optimize with Bayesian Optimization ----- #
 
+    # Initialize simulation model
     simulation_model = Simulation(initial_simulation_conditions, simulation_settings.return_type,
                                   race_type="ASC",
                                   golang=simulation_settings.golang)
     driving_hours = simulation_model.get_driving_hours()
     input_speed = np.array([30] * driving_hours)
 
+    # Run simulation model with a "guess" speed array
     unoptimized_time = simulation_model.run_model(speed=input_speed, plot_results=True,
                                                   verbose=simulation_settings.verbose,
                                                   route_visualization=simulation_settings.route_visualization)
 
+    # Set up optimization models
     bounds = InputBounds()
     bounds.add_bounds(driving_hours, 20, 60)
     optimization = BayesianOptimization(bounds, simulation_model.run_model)
     random_optimization = RandomOptimization(bounds, simulation_model.run_model)
 
+    # Perform optimization with Bayesian optimization
     results = optimization.maximize(init_points=3, n_iter=simulation_settings.optimization_iterations, kappa=10)
     optimized = simulation_model.run_model(speed=np.fromiter(results, dtype=float), plot_results=True,
                                            verbose=simulation_settings.verbose,
                                            route_visualization=simulation_settings.route_visualization)
 
+    # Perform optimization with random optimization
     results_random = random_optimization.maximize(iterations=simulation_settings.optimization_iterations)
     optimized_random = simulation_model.run_model(speed=np.fromiter(results_random, dtype=float), plot_results=True,
                                                   verbose=simulation_settings.verbose,


### PR DESCRIPTION
**Summary**

1. Speed array elements get "mapped" to a the _True_ values of a boolean array which consists of every hour of simulation, and True denotes that the car is driving during this hour. 
2. This means that optimization does not modify/control values that get set to 0 no matter what, hopefully improving stability/performance of optimization. 
3. Times we are allowed to drive and charge are now distinct, and car does not charge outside designated charging time. Specifically, driving time is now 9am-6pm, and charging time is 7/8am-8pm (ASC/FGSP).  

**Fixes**
1. Motor array is no longer modified by logical_and with not_charge in run_simulation_calculations.
3. Deceleration is now applied after timing constraints are applied, as timing constraints cause deceleration/acceleration that wasn't being accounted for as a result of deceleration being applied before constraints.  
