### PR TITLE
Improved Libraries to use faster pointer generation

### DIFF
--- a/simulation/common/exceptions.py
+++ b/simulation/common/exceptions.py
@@ -5,3 +5,7 @@ Contains all the custom exceptions used in the simulation package
 
 class BatteryEmptyError(Exception):
     pass
+
+
+class LibrariesNotFound(Exception):
+    pass

--- a/simulation/library/libraries.py
+++ b/simulation/library/libraries.py
@@ -277,9 +277,10 @@ class Libraries:
 
         """
 
-        output_array = array.array(Libraries.ctypes_dict[c_type], [0] * output_array_length)
-        output_array_pointer = (c_type * len(output_array)).from_buffer(output_array)
-        return output_array_pointer, output_array
+        output_array = np.array([0] * output_array_length)
+        output_array_copy = output_array.astype(c_type)
+        ptr = output_array_copy.ctypes.data_as(ctypes.POINTER(c_type))
+        return ptr, output_array_copy
 
     @staticmethod
     def generate_input_output_pointer(input_array, c_type):

--- a/simulation/library/libraries.py
+++ b/simulation/library/libraries.py
@@ -21,16 +21,7 @@ class Libraries:
         ctypes.c_int: 'i'
     }
 
-    def __init__(self, raiseExceptionOnFail=True):
-        """
-
-        :param raiseExceptionOnFail: Boolean to control whether an exception should be raised if Go libraries cant be
-        found. Should not be set to false unless that scenario is handled.
-
-        """
-
-        self.raiseExceptionOnFail = raiseExceptionOnFail
-
+    def __init__(self):
         self.go_directory = self.get_go_directory()
 
         # ----- Load Go Libraries ----- #
@@ -99,19 +90,15 @@ class Libraries:
                              os.path.isdir(os.path.join(binaries_directory, f))]
 
         # Try to find compatible binaries by checking until compatible binaries are found
-        try:
-            for binary_container in binary_containers:
-                try:
-                    ctypes.cdll.LoadLibrary(f"{binaries_directory}/{binary_container}/main.so")
-                    return f"{binaries_directory}/{binary_container}"
-                except:
-                    pass
-        except LibrariesNotFound:
-            if self.raiseExceptionOnFail:
-                raise LibrariesNotFound("GoLang libraries not found for your operating system. "
-                                        "Please either compile them for your operating system or disable GoLang usage "
-                                        "in Simulation instantiation.")
-            return None
+        for binary_container in binary_containers:
+            try:
+                ctypes.cdll.LoadLibrary(f"{binaries_directory}/{binary_container}/main.so")
+                return f"{binaries_directory}/{binary_container}"
+            except OSError:
+                pass
+        raise LibrariesNotFound("Go shared libraries not found for your platform. \n"
+                                "Please either compile them for your platform or disable Go usage\n"
+                                "in Simulation instantiation.\n")
 
     def found_compatible_binaries(self):
         """

--- a/simulation/library/libraries.py
+++ b/simulation/library/libraries.py
@@ -3,12 +3,15 @@ import pathlib
 import array
 import numpy as np
 import os
+from simulation.common.exceptions import LibrariesNotFound
 
 
 class Libraries:
     """
-    Manages all GoLang binaries, verifies compatibility, and contains GoLang implementations and pointer generation
+
+    Manages all GoLang libraries, verifies compatibility, and contains GoLang implementations and pointer generation
     methods.
+
     """
 
     # Dictionary for converting between ctypes and their corresponding single-character identifier.
@@ -21,13 +24,14 @@ class Libraries:
     def __init__(self, raiseExceptionOnFail=True):
         """
 
-        :param raiseExceptionOnFail: Boolean to control whether an exception should be raised if Go binaries cant be
+        :param raiseExceptionOnFail: Boolean to control whether an exception should be raised if Go libraries cant be
         found. Should not be set to false unless that scenario is handled.
 
         """
+
         self.raiseExceptionOnFail = raiseExceptionOnFail
 
-        self.go_directory = self.GetGoDirectory()
+        self.go_directory = self.get_go_directory()
 
         # ----- Load Go Libraries ----- #
 
@@ -78,10 +82,10 @@ class Libraries:
                 ctypes.c_long
             ]
 
-    def GetGoDirectory(self):
+    def get_go_directory(self):
         """
 
-        Will get the directory to compatible go binaries else return None/raise an exception.
+        Will get the directory to compatible Go libraries else return None/raise an exception.
 
         :returns: Path to compatible GoLang binaries
         :rtype: str
@@ -102,19 +106,19 @@ class Libraries:
                     return f"{binaries_directory}/{binary_container}"
                 except:
                     pass
-        except:
+        except LibrariesNotFound:
             if self.raiseExceptionOnFail:
-                raise Exception("GoLang binaries not found for your operating system. "
-                                "Please either compile them for your operating system or disable GoLang usage "
-                                "in Simulation instantiation.")
+                raise LibrariesNotFound("GoLang libraries not found for your operating system. "
+                                        "Please either compile them for your operating system or disable GoLang usage "
+                                        "in Simulation instantiation.")
             return None
 
     def found_compatible_binaries(self):
         """
 
-        Check if compatible Go binaries were found and loaded.
+        Check if compatible Go libraries were found and loaded.
 
-        :returns: Boolean which indicates if compatible Go binaries were found and loaded.
+        :returns: Boolean which indicates if compatible Go libraries were found and loaded.
         :rtype: bool
 
         """
@@ -138,9 +142,9 @@ class Libraries:
         # Execute the Go shared library (compiled Go function) and pass it the pointers we generated
         self.main_library.closest_gis_indices_loop(
             average_distances_pointer,
-            len(average_distances_pointer),
+            len(average_distances),
             cumulative_distances_pointer,
-            len(cumulative_distances_pointer),
+            len(cumulative_distances),
             results_pointer,
             len(results),
         )
@@ -157,7 +161,8 @@ class Libraries:
         # Generate pointers to arrays to pass to a Go binary
         unix_timestamps_pointer = Libraries.generate_input_pointer(unix_timestamps, ctypes.c_double)
         dt_local_arr_pointer = Libraries.generate_input_pointer(dt_local_array, ctypes.c_double)
-        closest_time_stamp_indices_pointer, closest_time_stamp_indices = Libraries.generate_output_pointer(unix_timestamps, ctypes.c_double)
+        closest_time_stamp_indices_pointer, closest_time_stamp_indices = Libraries.generate_output_pointer(
+            unix_timestamps, ctypes.c_double)
 
         # Execute the Go shared library (compiled Go function) and pass it the pointers we generated
         self.main_library.weather_in_time_loop(
@@ -179,7 +184,8 @@ class Libraries:
         # Get pointers for GoLang
         cumulative_distances_pointer = Libraries.generate_input_pointer(cumulative_distances, ctypes.c_double)
         average_distances_pointer = Libraries.generate_input_pointer(average_distances, ctypes.c_double)
-        closest_weather_indices_pointer, closest_weather_indices = Libraries.generate_output_pointer(len(cumulative_distances), ctypes.c_long)
+        closest_weather_indices_pointer, closest_weather_indices = Libraries.generate_output_pointer(
+            len(cumulative_distances), ctypes.c_long)
 
         self.main_library.closest_weather_indices_loop(
             cumulative_distances_pointer,
@@ -187,7 +193,7 @@ class Libraries:
             average_distances_pointer,
             len(average_distances),
             closest_weather_indices_pointer,
-            len(closest_weather_indices_pointer)
+            len(closest_weather_indices)
         )
 
         return np.array(closest_weather_indices, 'i')
@@ -223,7 +229,7 @@ class Libraries:
         """
 
         # We need to flatten waypoints from a [1x7] matrix to a 1D array.
-        flattened_waypoints = np.array([0]*len(waypoints))
+        flattened_waypoints = np.array([0] * len(waypoints))
         for i in range(len(waypoints)):
             flattened_waypoints[i] = waypoints[i][0]
 
@@ -247,28 +253,30 @@ class Libraries:
     def generate_input_pointer(input_array, c_type):
         """
 
-        Generate a pointer to an input array to be passed to compiled Go binaries.
+        Generate a pointer to an input array to be passed to a compiled Go library.
 
         :param input_array: Array in which a pointer will be generated for
         :param c_type: The corresponding ctypes type for input_array
         :return: A pointer pointing to input_array
 
         """
-        array_copy = array.array(Libraries.ctypes_dict[c_type], input_array)
-        array_copy_pointer = (c_type * len(array_copy)).from_buffer(array_copy)
-        return array_copy_pointer
+
+        input_array_copy = input_array.astype(c_type)
+        ptr = input_array_copy.ctypes.data_as(ctypes.POINTER(c_type))
+        return ptr
 
     @staticmethod
     def generate_output_pointer(output_array_length, c_type):
         """
 
-        Generate an array and a pointer to that array for a Go binary to write to.
+        Generate an array and a pointer to that array for a Go library to write to.
 
         :param output_array_length: Length of the output array
         :param c_type: The corresponding ctypes type for the output array
         :return: A pointer pointing to output_array, and output array itself
 
         """
+
         output_array = array.array(Libraries.ctypes_dict[c_type], [0] * output_array_length)
         output_array_pointer = (c_type * len(output_array)).from_buffer(output_array)
         return output_array_pointer, output_array
@@ -277,7 +285,7 @@ class Libraries:
     def generate_input_output_pointer(input_array, c_type):
         """
 
-        Generate an array and a pointer to that array for a Go binary to write to that is equal to an existing array.
+        Generate an array and a pointer to that array for a Go library to write to that is equal to an existing array.
         This is useful if you want to modify an array instead of creating a new one.
 
         :param input_array: Array in which a pointer will be generated for
@@ -285,6 +293,7 @@ class Libraries:
         :return: A pointer pointing to output_array, and output array itself
 
         """
+
         output_array = array.array(Libraries.ctypes_dict[c_type], input_array)
         output_array_pointer = (c_type * len(output_array)).from_buffer(output_array)
         return output_array_pointer, output_array


### PR DESCRIPTION
Changed pointer generation for Go library inputs and outputs to avoid the slow array copy that the previous method required. This reduces the runtime of `generate_input_pointer` from ~14% to ~2%, with a similar speedup for `generate_output_pointer`. 

Note: 
1. Better documentation and exception handling has also been added.
2. The faster generation technique is not in use for the `generate_input_output_pointer` pointer generator as the purpose of that function being distinct from the other two is to explicitly generate a copy of the input array. 